### PR TITLE
node-webkit issue #199 - for native modules renaming nw.exe breaks

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 @echo off
 
 set CUR_DIR="%CD%"
-set EXE_PATH=%CUR_DIR%\release\app.exe
+set EXE_PATH=%CUR_DIR%\release\nw.exe
 set ICO_PATH=%CUR_DIR%\app\app.ico
 set NWEXE_PATH=%CUR_DIR%\buildTools\nw\nw.exe
 set NWZIP_PATH=%CUR_DIR%\release\app.nw
@@ -22,7 +22,7 @@ if not exist release md release
 echo.
 call :ColorText 0a "Creating app package..."
 cd buildTools\7z
-7z a -tzip %NWZIP_PATH% %CUR_DIR%\app\*
+7z a -r -tzip %NWZIP_PATH% ..\..\app\*
 cd ..\..
 
 echo.


### PR DESCRIPTION
Hi

when using native modules on windows renaming nw.exe into smth different causes wird behaviour ("Error no error") as described in https://github.com/rogerwang/node-webkit/issues/199. So I updated build script to reflect that - you can check if beahiour is the same by downloading my maracuya-project package: http://maracuya-jukebox.com/download/maracuya.zip. 

Probably it would be better to add some kind of flag whether renaming should be enabled or not and what are the consequences.

Thanks
Marek
