### PR TITLE
Update build.linux.sh

### DIFF
--- a/build.linux.sh
+++ b/build.linux.sh
@@ -8,7 +8,9 @@ CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "Creating bundle for linux-ia32..."
 mkdir -p release.linux-ia32
 rm -f release.linux-ia32/app.nw
-zip -b app -r release.linux-ia32/app.nw app/*
+cd app
+zip -r ../release.linux-ia32/app.nw *
+cd ..
 cat buildTools/nw.linux-ia32/nw release.linux-ia32/app.nw > release.linux-ia32/app
 chmod +x release.linux-ia32/app
 if [ ! -f release.linux-ia32/nw.pak ]; then


### PR DESCRIPTION
package.json and other app files should be contained in the root of the .nw archive, not in /app subfolder (e.g. app.nw/app/package.json)
Before correcting this the generated app executable opened up on nw:blank
