### PR TITLE
handle spaces in paths on osx

### DIFF
--- a/build.osx.ia32.sh
+++ b/build.osx.ia32.sh
@@ -3,18 +3,18 @@ echo "nodebob v0.1"
 echo "---"
 echo
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-mkdir -p $CUR_DIR/release.osx/nw
+mkdir -p "$CUR_DIR/release.osx/nw"
 
 echo "Extracting node-webkit..."
-rm -Rf $CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-ia32
-unzip $CUR_DIR/buildTools/nw.osx/node-webkit-v0.10.5-osx-ia32.zip -d $CUR_DIR/release.osx/nw > /dev/null
+rm -Rf "$CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-ia32"
+unzip "$CUR_DIR/buildTools/nw.osx/node-webkit-v0.10.5-osx-ia32.zip" -d "$CUR_DIR/release.osx/nw" > /dev/null
 echo "Creating bundle for osx..."
-rm -Rf $CUR_DIR/release.osx/app.app
-cp -R $CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-ia32/node-webkit.app $CUR_DIR/release.osx/app.app
-cp -R $CUR_DIR/app $CUR_DIR/release.osx/app.app/Contents/Resources/app.nw
-cp $CUR_DIR/app/Info.plist $CUR_DIR/release.osx/app.app/Contents/Info.plist
-sips -s format tiff $CUR_DIR/app/app.ico --out $CUR_DIR/release.osx/app_icon.tiff > /dev/null
-tiff2icns -noLarge $CUR_DIR/release.osx/app_icon.tiff $CUR_DIR/release.osx/app.app/Contents/Resources/nw.icns
+rm -Rf "$CUR_DIR/release.osx/app.app"
+cp -R "$CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-ia32/node-webkit.app" "$CUR_DIR/release.osx/app.app"
+cp -R "$CUR_DIR/app" "$CUR_DIR/release.osx/app.app/Contents/Resources/app.nw"
+cp "$CUR_DIR/app/Info.plist" "$CUR_DIR/release.osx/app.app/Contents/Info.plist"
+sips -s format tiff "$CUR_DIR/app/app.ico" --out "$CUR_DIR/release.osx/app_icon.tiff" > /dev/null
+tiff2icns -noLarge "$CUR_DIR/release.osx/app_icon.tiff" "$CUR_DIR/release.osx/app.app/Contents/Resources/nw.icns"
 echo "Deleting temporary files..."
-rm -Rf $CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-ia32 $CUR_DIR/release.osx/app_icon.tiff
+rm -Rf "$CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-ia32" "$CUR_DIR/release.osx/app_icon.tiff"
 echo "Done!"

--- a/build.osx.x64.sh
+++ b/build.osx.x64.sh
@@ -3,18 +3,18 @@ echo "nodebob v0.1"
 echo "---"
 echo
 CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-mkdir -p $CUR_DIR/release.osx/nw
+mkdir -p "$CUR_DIR/release.osx/nw"
 
 echo "Extracting node-webkit..."
-rm -Rf $CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-x64
-unzip $CUR_DIR/buildTools/nw.osx/node-webkit-v0.10.5-osx-x64.zip -d $CUR_DIR/release.osx/nw > /dev/null
+rm -Rf "$CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-x64"
+unzip "$CUR_DIR/buildTools/nw.osx/node-webkit-v0.10.5-osx-x64.zip" -d "$CUR_DIR/release.osx/nw" > /dev/null
 echo "Creating bundle for osx..."
-rm -Rf $CUR_DIR/release.osx/app.app
-cp -R $CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-x64/node-webkit.app $CUR_DIR/release.osx/app.app
-cp -R $CUR_DIR/app $CUR_DIR/release.osx/app.app/Contents/Resources/app.nw
-cp $CUR_DIR/app/Info.plist $CUR_DIR/release.osx/app.app/Contents/Info.plist
-sips -s format tiff $CUR_DIR/app/app.ico --out $CUR_DIR/release.osx/app_icon.tiff > /dev/null
-tiff2icns -noLarge $CUR_DIR/release.osx/app_icon.tiff $CUR_DIR/release.osx/app.app/Contents/Resources/nw.icns
+rm -Rf "$CUR_DIR/release.osx/app.app"
+cp -R "$CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-x64/node-webkit.app" "$CUR_DIR/release.osx/app.app"
+cp -R "$CUR_DIR/app" "$CUR_DIR/release.osx/app.app/Contents/Resources/app.nw"
+cp "$CUR_DIR/app/Info.plist" "$CUR_DIR/release.osx/app.app/Contents/Info.plist"
+sips -s format tiff "$CUR_DIR/app/app.ico" --out "$CUR_DIR/release.osx/app_icon.tiff" > /dev/null
+tiff2icns -noLarge "$CUR_DIR/release.osx/app_icon.tiff" "$CUR_DIR/release.osx/app.app/Contents/Resources/nw.icns"
 echo "Deleting temporary files..."
-rm -Rf $CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-x64 $CUR_DIR/release.osx/app_icon.tiff
+rm -Rf "$CUR_DIR/release.osx/nw/node-webkit-v0.10.5-osx-x64" "$CUR_DIR/release.osx/app_icon.tiff"
 echo "Done!"


### PR DESCRIPTION
I have wrapped path names in double quotes, but only on osx since I have no Linux. Problem seems not to exist on Windows.
